### PR TITLE
add get_help() to retrieve the config help dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 **Unreleased** is available in Github's `master` branch, but not on PyPI.
+
+## [3.0.2](https://pypi.org/project/pyvalhalla/3.0.2/) - 2021-03-10
+
+### ADDED
+
+- `valhalla.get_help()` to return valhalla_build_config help dictionary
 
 ## [3.0.1](https://pypi.org/project/pyvalhalla/3.0.1/) - 2021-03-08
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This spin-off project simply offers packaged Python bindings to the fantastic [V
 
 Over time we will very likely deviate from Valhalla's own Python binding code to allow usages outside the scope of the core project. Refer to our [release pattern](./docs/releasing.md) to learn more about the versioning of this project.
 
+**Note**, the performance boost using these bindings compared to requesting an HTTP service is tremendous: on 500 random routes in Berlin, the bindings take 27 secs while HTTP on localhost takes 127 secs.
+
 ## Installation
  
 We distribute all 4 currently developed CPython versions as **binary wheels** for Win64, MacOS (Intel) and x86_64 Linux distributions with `glibc>=2.24` (most modern systems, see [PEP 600](https://www.python.org/dev/peps/pep-0600/)). We **do not** offer a source distribution on PyPI. Please contact us on enquiry@gis-ops.com if you need support building the bindings for your platform/distribution.
@@ -21,10 +23,13 @@ Before using the Python bindings you need to have access to a routable Valhalla 
 
 Once you have created a graph locally, you can use it like this:
 ```python
-from valhalla import Actor, get_config
+from valhalla import Actor, get_config, get_help
 
 # generate configuration
 config = get_config(tile_extract='path/to/extract.tar', verbose=True)
+
+# print the help for specific config items (has the same structure as the output of get_config()
+print(get_help()["service_limits"]["auto"]["max_distance"])
 
 # instantiate Actor to load graph and call actions
 actor = Actor(config)

--- a/valhalla/__init__.py
+++ b/valhalla/__init__.py
@@ -1,5 +1,5 @@
 from .actor import Actor
-from .config import get_config
+from .config import get_config, get_help
 from ._valhalla import *
 from .__version__ import __version__
 

--- a/valhalla/config.py
+++ b/valhalla/config.py
@@ -1,7 +1,7 @@
 from pathlib import Path
-from typing import Union
+from typing import Union, Dict
 
-from .valhalla_build_config import config as default_config, Optional
+from .valhalla_build_config import config as default_config, Optional, help_text
 
 
 def _sanitize_config(dict_: dict = None) -> dict:
@@ -14,6 +14,13 @@ def _sanitize_config(dict_: dict = None) -> dict:
             _sanitize_config(v)
 
     return dict_
+
+
+def get_help() -> Dict[str, Union[Dict[str, str], str]]:
+    """
+    Returns the help dictionary with the same keys as the config JSON.
+    """
+    return help_text
 
 
 def get_config(


### PR DESCRIPTION
fixes #11 

can be imported from the package root, e.g. `valhalla.get_help()["service_limits"]["auto"]["max_distance"]`